### PR TITLE
Revisit sysctl params for Ubuntu 24.04

### DIFF
--- a/roles/common/tasks/system_tuner.yaml
+++ b/roles/common/tasks/system_tuner.yaml
@@ -10,33 +10,29 @@
     # TCP buffer sizes (10k, 87.38k (linux default), 12M resp)
     - { name: 'net.ipv4.tcp_rmem', value: '10240 87380 12582912' }
     - { name: 'net.ipv4.tcp_wmem', value: '10240 87380 12582912' }
-    # Enable TCP westwood for kernels >= 2.6.13
-    - { name: 'net.ipv4.tcp_congestion_control', value: 'westwood' }
     - { name: 'net.ipv4.tcp_fastopen', value: '3' }
-    - { name: 'net.ipv4.tcp_timestamps', value: '0' }
+    - { name: 'net.ipv4.tcp_timestamps', value: '1' }
     - { name: 'net.ipv4.tcp_sack', value: '1' }
-    - { name: 'net.ipv4.tcp_low_latency', value: '1' }
-    # Enable fast recycling TIME-WAIT sockets
-    - { name: 'net.ipv4.tcp_tw_reuse', value: '1' }
     # Don't cache ssthresh from previous connection
-    - { name: 'net.ipv4.tcp_no_metrics_save', value: '1' }
     - { name: 'net.ipv4.tcp_moderate_rcvbuf', value: '1' }
     # Kernel tuning
     - { name: 'kernel.timer_migration', value: '0' }
     - { name: 'kernel.hung_task_timeout_secs', value: '30' }
-    - { name: 'kernel.pid_max', value: '49152' }
     # VM tuning
     - { name: 'vm.swappiness', value: '30' }
     - { name: 'vm.max_map_count', value: '2000000' }
     - { name: 'vm.stat_interval', value: '10' }
-    - { name: 'vm.dirty_ratio', value: '40' }
-    - { name: 'vm.dirty_background_ratio', value: '10' }
-    - { name: 'vm.min_free_kbytes', value: '3000000' }
-    - { name: 'vm.dirty_expire_centisecs', value: '36000' }
-    - { name: 'vm.dirty_writeback_centisecs', value: '3000' }
+    # 4 GiB
+    - { name: 'vm.dirty_bytes', value: '4294967296' }
+    # 1 GiB
+    - { name: 'vm.dirty_background_bytes', value: '1073741824' }
+    # 256 MiB
+    - { name: 'vm.min_free_kbytes', value: '262144' }
+    # 30 seconds
+    - { name: 'vm.dirty_expire_centisecs', value: '3000' }
+    # 5 seconds
+    - { name: 'vm.dirty_writeback_centisecs', value: '500' }
     - { name: 'vm.dirtytime_expire_seconds', value: '43200' }
     # Network core tuning
     - { name: 'net.core.rmem_max', value: '134217728' }
-    - { name: 'net.core.rmem_default', value: '134217728' }
     - { name: 'net.core.wmem_max', value: '134217728' }
-    - { name: 'net.core.wmem_default', value: '134217728' }


### PR DESCRIPTION
* Removal of `net.ipv4.tcp_congestion_control = westwood`
  Westwood is mainly aimed at lossy / wireless-ish paths. [TUM Info VIII](https://www.net.in.tum.de/fileadmin/TUM/NET/NET-2019-06-1/NET-2019-06-1_03.pdf)
  In AWS/DC networks it’s often not the best default. If you change CCAs, do it based on measurement. Also note that available CCAs depend on what’s loaded/available.
* Enable `net.ipv4.tcp_timestamps` and remove(switch to default) `net.ipv4.tcp_tw_reuse`
  `tcp_tw_reuse` relies on timestamps for its “safe reuse” logic; it reuses TIME_WAIT ports when the new timestamp is greater than the previous one. So turning timestamps off while enabl
* Remove `net.ipv4.tcp_low_latency` This one is basically obsolete / removed (legacy no-op). 
[patchwork.ozlabs.org](https://patchwork.ozlabs.org/patch/847528/?utm_source=chatgpt.com).
* Remove `net.ipv4.tcp_no_metrics_save = 1`
  Kernel + man-page docs: by default TCP caches per-destination metrics and usually that improves performance; this disables that cache. https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt?utm_source=chatgpt.com
* Remove `kernel.pid_max`
  49152 is an artificially low cap. On 64-bit kernels, pid_max can be much higher (commonly up to ~4 million). If you ever have many processes/threads/short-lived workers, this can become a real operational failure mode for zero benefit. https://stackoverflow.com/questions/9361816/maximum-number-of-processes-in-linux?utm_source=chatgpt.com|
* Remove `net.core.rmem_default` / `net.core.wmem_default`
  128MB is a bad global default. Kernel docs: rmem_default is the default socket receive buffer size (bytes); same idea for send. docs.kernel.org](https://docs.kernel.org/admin-guide/sysctl/net.html) Setting defaults to 128MB means new sockets start huge → memory waste and cache pressure, especially with many connections

* Replace `vm.dirty_ratio` and `vm.dirty_background_ratio` with concrete values and lower them.
  Ratios are the problem on large-memory machines. Kernel docs explicitly treat bytes as the “counterpart” of ratios; only one should be set. https://www.kernel.org/doc/Documentation/admin-guide/sysctl/vm.rst?utm_source=chatgpt.com
  If throughput drops too much, relax dirty_bytes upward (e.g. 6–12 GiB). If latency is still spiky, tighten it downward. In our case TPS didn't drop, but we can experiment with increasing it later.
  Expire/writeback were long. For steadier IO it has been reduce.  Bring the timers back toward sane defaults.
  

## Soak Load

Last section is the load with 800 workers (from 2 machines):

<img width="1493" height="746" alt="Screenshot 2025-12-16 at 20 33 27" src="https://github.com/user-attachments/assets/46571f83-552d-476c-91dc-7532095f9124" />
ing tcp_tw_reuse is at best self-defeating and at worst can lead to edge-case weirdness.