### PR TITLE
Adding rollup rate limits support

### DIFF
--- a/roles/rollup/defaults/main.yaml
+++ b/roles/rollup/defaults/main.yaml
@@ -76,6 +76,28 @@ rollup_max_batch_size_bytes: 7340032
 rollup_max_concurrent_blobs: 128
 rollup_max_allowed_node_distance_behind: 10
 
+# Rate limiter - only applies to preferred sequencer
+rollup_rate_limiter_enabled: false
+rollup_rate_limiter_max_concurrent_users: 100000
+rollup_rate_limiter_max_requests_per_second: 10000
+# Default limits (resources measured in 1/1000th of full batch capacity)
+rollup_rate_limiter_default_resources_per_bucket: 5
+rollup_rate_limiter_default_refill_rate: 5
+# Custom limits per address
+# Example:
+#   rollup_rate_limiter_address_limits:
+#     - address: "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
+#       resources_per_bucket: 20
+#       refill_rate: 2
+rollup_rate_limiter_address_limits: []
+# Custom limits per IP
+# Example:
+#   rollup_rate_limiter_ip_limits:
+#     - ip: "127.0.0.1"
+#       resources_per_bucket: 1000
+#       refill_rate: 1
+rollup_rate_limiter_ip_limits: []
+
 # Network ports
 rollup_http_host: "127.0.0.1"
 rollup_http_port: 12346

--- a/roles/rollup/templates/rollup_config.toml.j2
+++ b/roles/rollup/templates/rollup_config.toml.j2
@@ -62,3 +62,19 @@ priority_fee_percentage = 0
 max_fee = 100_000_000
 interval_millis = 50
 {% endif %}
+
+{% if rollup_sequencer_kind == "preferred" and rollup_rate_limiter_enabled %}
+[sequencer.preferred.rate_limiter]
+max_nb_of_concurrent_users_in_rate_limiter = {{ rollup_rate_limiter_max_concurrent_users }}
+max_requests_per_second = {{ rollup_rate_limiter_max_requests_per_second }}
+{% if rollup_rate_limiter_address_limits | length > 0 %}
+address_custom_limits = [{% for item in rollup_rate_limiter_address_limits %}["{{ item.address }}", { resources_per_bucket = {{ item.resources_per_bucket }}, refill_rate = {{ item.refill_rate }} }]{% if not loop.last %}, {% endif %}{% endfor %}]
+{% endif %}
+{% if rollup_rate_limiter_ip_limits | length > 0 %}
+ip_custom_limits = [{% for item in rollup_rate_limiter_ip_limits %}["{{ item.ip }}", { resources_per_bucket = {{ item.resources_per_bucket }}, refill_rate = {{ item.refill_rate }} }]{% if not loop.last %}, {% endif %}{% endfor %}]
+{% endif %}
+
+[sequencer.preferred.rate_limiter.default_limits]
+resources_per_bucket = {{ rollup_rate_limiter_default_resources_per_bucket }}
+refill_rate = {{ rollup_rate_limiter_default_refill_rate }}
+{% endif %}

--- a/vars/custom_overrides.yaml.example
+++ b/vars/custom_overrides.yaml.example
@@ -55,6 +55,28 @@
 # wipe: false
 
 # ============================================
+# Rate Limiter (Preferred Sequencer Only)
+# ============================================
+
+# rollup_rate_limiter_enabled: true
+# rollup_rate_limiter_max_concurrent_users: 100000
+# rollup_rate_limiter_max_requests_per_second: 10000
+# rollup_rate_limiter_default_resources_per_bucket: 5
+# rollup_rate_limiter_default_refill_rate: 5
+
+# Custom limits per address (resources in 1/1000th of batch capacity)
+# rollup_rate_limiter_address_limits:
+#   - address: "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
+#     resources_per_bucket: 20
+#     refill_rate: 2
+
+# Custom limits per IP
+# rollup_rate_limiter_ip_limits:
+#   - ip: "127.0.0.1"
+#     resources_per_bucket: 1000
+#     refill_rate: 1
+
+# ============================================
 # Data Availability - Mock DA
 # ============================================
 


### PR DESCRIPTION
Adds new params for rate limit support in rollup. Examples are provided

Tested manually:

```
[sequencer.preferred.rate_limiter]
max_nb_of_concurrent_users_in_rate_limiter = 320000
max_requests_per_second = 44000
address_custom_limits = [["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085", { resources_per_bucket = 356, refill_rate = 4 }]]
ip_custom_limits = [["8.8.4.4", { resources_per_bucket = 1030, refill_rate = 8 }]]
```