### PR TITLE
Fsync after taking a backup (and after restoring it).

### DIFF
--- a/roles/rollup/templates/restore-from-snapshot.sh.j2
+++ b/roles/rollup/templates/restore-from-snapshot.sh.j2
@@ -165,6 +165,8 @@ if [ "$FORCE" != "true" ]; then
     echo "  3. Restore data from $SOURCE_DESC"
     echo "  4. Restart the rollup service"
     echo ""
+    echo "!!NOTE!! Restoration can take 1-3 hours. Make sure you are in a \`screen\` or \`tmux\` session before proceeding, so that connection loss does not abort the process!!"
+    echo ""
     read -p "Are you sure you want to proceed? (type 'yes' to confirm): " CONFIRM
     if [ "$CONFIRM" != "yes" ]; then
         echo "Aborted."
@@ -178,7 +180,7 @@ sudo systemctl stop rollup || true
 
 # Create volume from snapshot if needed
 if [ "$SOURCE_TYPE" = "snapshot" ]; then
-    log "Creating temporary volume from snapshot (this may take a while for large snapshots)..."
+    log "Creating temporary volume from snapshot..."
     VOLUME_ID=$(aws ec2 create-volume \
         --region "$AWS_REGION" \
         --availability-zone "$AVAILABILITY_ZONE" \
@@ -263,8 +265,9 @@ fi
 log "Clearing existing data in $ROLLUP_DATA_DIR..."
 sudo rm -rf "${ROLLUP_DATA_DIR:?}"/*
 
-log "Restoring data (this may take a while for large datasets)..."
-sudo rsync -ah --info=progress2 "$TEMP_MOUNT/rollup/" "$ROLLUP_DATA_DIR/"
+log "Restoring data. This will take a while. Expect the rate to be very slow until the EBS volume is warmed up - this is normal and should speed up dramatically."
+sudo rsync -ah --fsync --info=progress2 "$TEMP_MOUNT/rollup/" "$ROLLUP_DATA_DIR/"
+sync
 
 # Fix ownership
 log "Fixing ownership..."

--- a/roles/rollup/templates/snapshot-rollup-data.sh.j2
+++ b/roles/rollup/templates/snapshot-rollup-data.sh.j2
@@ -24,14 +24,14 @@ sudo systemctl stop rollup
 
 # Rsync rollup data to snapshots disk, ensuring rollup restarts regardless of outcome
 log "Syncing $ROLLUP_DATA_DIR to $SNAPSHOT_DIR..."
-if ! rsync -a --delete --exclude='lost+found' "$ROLLUP_DATA_DIR/" "$SNAPSHOT_DIR/rollup/"; then
+if ! rsync -a --fsync --delete --exclude='lost+found' "$ROLLUP_DATA_DIR/" "$SNAPSHOT_DIR/rollup/"; then
     log "ERROR: Rsync failed!"
     log "Restarting rollup service..."
     sudo systemctl start rollup
     log "Rollup restarted. Exiting due to rsync failure."
     exit 1
 fi
-
+sync
 log "Sync complete."
 
 # Restart the rollup service
@@ -51,7 +51,9 @@ SERIAL=$(sudo nvme id-ctrl -v "$SNAPSHOTS_DEVICE" 2>/dev/null | grep -i "^sn" | 
 if [[ "$SERIAL" =~ ^vol ]]; then
     # Insert dash after "vol" to get proper volume ID format
     VOLUME_ID="vol-${SERIAL:3}"
-    log "Snapshots disk volume ID: $VOLUME_ID"
+    log "Snapshots disk volume ID: $VOLUME_ID. Unmounting it from $SNAPSHOT_DIR..."
+    sudo umount "$SNAPSHOT_DIR"
+    log "Triggering AWS snapshot"
 
     # Create EBS snapshot with descriptive tags
     TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -64,6 +66,8 @@ if [[ "$SERIAL" =~ ^vol ]]; then
         --output text)
 
     log "EBS snapshot initiated: $SNAPSHOT_ID"
+    sudo mount "$SNAPSHOT_DIR"
+    log "Remounted snapshot directory."
 else
     log "ERROR: Could not determine volume ID from device $SNAPSHOTS_DEVICE (serial: $SERIAL)"
 fi


### PR DESCRIPTION
Backup node also unmounts snapshots directory for safety.

Some of the parameters may be redundant (e.g. `--fsync` and `sync` together) but this script has now been tested on a production rollup, and having them all together doesn't cost anything.