### PR TITLE
Add support for contract deployer allowlist

### DIFF
--- a/roles/rollup/defaults/main.yaml
+++ b/roles/rollup/defaults/main.yaml
@@ -54,6 +54,10 @@ rollup_genesis_extra_addresses:
   - "0x74bb92E136628E7028e2290fF60A8EC83Eea904f"
 rollup_genesis_evm_block_gas_limit: 1000000000
 
+
+rollup_genesis_evm_allow_all_contract_creation: true 
+rollup_genesis_evm_contract_creation_allowlist: []
+
 # Both ZK/Optimistic Verifier is attester or prover
 rollup_genesis_verifier_min_bond: [1000, 1000]
 rollup_genesis_verifier_init_bond: 200000

--- a/roles/rollup/templates/genesis.json.j2
+++ b/roles/rollup/templates/genesis.json.j2
@@ -94,7 +94,17 @@
   "value_setter": null,
   "evm": {
     "accounts": [],
-    "contract_creation_policy": "everyone",
+    "contract_creation_policy": {%- if rollup_genesis_evm_allow_all_contract_creation %} "everyone",
+{%- else %}
+{ 
+      "allowlist": [
+{%- for address in rollup_genesis_evm_contract_creation_allowlist %}
+"{{ address }}"{% if not loop.last %}, {% endif %}
+{%- endfor %}
+] 
+    },
+{%- endif %}
+
     "initial_base_fee": 7,
     "genesis_timestamp": 0,
     "chain_spec": {


### PR DESCRIPTION
Example rendered configs: 
```
    "contract_creation_policy":{ 
      "allowlist": ["0xe7d2b7610d1574610cbd903ea896c59d17470633", "0x23B6445f524daDee9fb576627740AaD23Afbe8b7"] 
    },
  ```

and 

```
"contract_creation_policy": "everyone",
```

I've manually tested that this syntax works on demo-rollup.