### PR TITLE
Add support for Chain Hash Overrides. Fix minor bugs

### DIFF
--- a/cloud-init-userdata.sh.example
+++ b/cloud-init-userdata.sh.example
@@ -39,6 +39,8 @@ ROLLUP_CHAIN_NAME=""
 ROLLUP_HYPERLANE_BRIDGE_DOMAIN=""
 ROLLUP_DEFERRED_SLOTS_COUNT=""
 ROLLUP_HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT=""
+# JSON array of objects, e.g.: '[{"start_height": 0, "end_height": 1000, "chain_hash": "0xabc...", "grace_period": 100}]'
+ROLLUP_CHAIN_HASH_OVERRIDES=""
 
 # Secrets (CDK should retrieve from AWS Secrets Manager or SSM)
 # CELESTIA_GRPC_AUTH_TOKEN=""
@@ -190,6 +192,12 @@ if [[ -n "${ROLLUP_HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT:-}" ]]; then
     cat >> "$RUNTIME_VARS_FILE" << EOF
 rollup_hyperlane_meter_delivery_counter_after_height: $ROLLUP_HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT
 EOF
+fi
+
+if [[ -n "${ROLLUP_CHAIN_HASH_OVERRIDES:-}" ]]; then
+    # Convert JSON array to YAML list format
+    echo "rollup_chain_hash_overrides:" >> "$RUNTIME_VARS_FILE"
+    echo "$ROLLUP_CHAIN_HASH_OVERRIDES" | jq -r '.[] | "  - start_height: \(.start_height)\n    end_height: \(.end_height)\n    chain_hash: \"\(.chain_hash)\"\n    grace_period: \(.grace_period)"' >> "$RUNTIME_VARS_FILE"
 fi
 
 # Secure the file (contains secrets)

--- a/roles/rollup-build/defaults/main.yaml
+++ b/roles/rollup-build/defaults/main.yaml
@@ -132,3 +132,11 @@ publish_reverted_evm_txs: false
 # rollup_custom_gas_token_id: "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"
 # rollup_evm_max_fee_check_height: 0
 # rollup_hyperlane_meter_delivery_counter_after_height: 0
+# Chain hash overrides (list of objects)
+# Example:
+#   rollup_chain_hash_overrides:
+#     - start_height: 0
+#       end_height: 1000
+#       chain_hash: "0xabc...32_bytes_hex"
+#       grace_period: 100
+rollup_chain_hash_overrides: []

--- a/roles/rollup-build/tasks/build_config.yaml
+++ b/roles/rollup-build/tasks/build_config.yaml
@@ -108,6 +108,16 @@
     backup: no
   when: rollup_custom_gas_token_id is defined and rollup_custom_gas_token_id | string | length > 0
 
+- name: update CHAIN_HASH_OVERRIDES in constants.toml
+  become: true
+  become_user: ubuntu
+  ansible.builtin.replace:
+    path: "/home/ubuntu/{{ rollup_repo_dir }}/constants.toml"
+    regexp: '^CHAIN_HASH_OVERRIDES\s*=.*$'
+    replace: 'CHAIN_HASH_OVERRIDES = [{% for item in rollup_chain_hash_overrides %}{ start_height = {{ item.start_height }}, end_height = {{ item.end_height }}, chain_hash = "{{ item.chain_hash }}", grace_period = {{ item.grace_period }} }{% if not loop.last %}, {% endif %}{% endfor %}]'
+    backup: no
+  when: rollup_chain_hash_overrides is defined and rollup_chain_hash_overrides | length > 0
+
 - name: update EVM_MAX_FEE_CHECK_HEIGHT in constants.toml
   become: true
   become_user: ubuntu

--- a/roles/rollup-build/templates/rollup_config.toml.j2
+++ b/roles/rollup-build/templates/rollup_config.toml.j2
@@ -34,6 +34,7 @@ max_concurrent_blobs = {{ rollup_max_concurrent_blobs }}
 max_allowed_node_distance_behind = {{ rollup_max_allowed_node_distance_behind }}
 rollup_address = "{{ rollup_sequencer_address }}"
 blob_processing_timeout_secs = 60
+admin_addresses = ["{{ rollup_sequencer_address }}"]
 
 {% if rollup_sequencer_kind == "preferred" %}
 [sequencer.preferred]

--- a/roles/rollup/tasks/multi_version_build.yaml
+++ b/roles/rollup/tasks/multi_version_build.yaml
@@ -25,12 +25,20 @@
     name: version_spec
   when: rollup_config_repo is defined and rollup_config_repo | length > 0
 
+- name: Detect current ansible repo commit
+  ansible.builtin.command:
+    cmd: git rev-parse HEAD
+    chdir: "{{ playbook_dir }}"
+  register: ansible_repo_head
+  changed_when: false
+  when: ansible_commit is not defined
+
 - name: Synthesize single-version spec (if not provided)
   set_fact:
     version_spec:
       rollup_versions:
         - version_id: "v0"
-          ansible_commit: "{{ ansible_commit | default('main') }}"
+          ansible_commit: "{{ ansible_commit | default(ansible_repo_head.stdout) }}"
           vars_file: ""
           start_height: null
           stop_height: null
@@ -45,7 +53,7 @@
   git:
     repo: "{{ ansible_repo_url }}"
     dest: "{{ ansible_checkout_dir }}"
-    version: "main"
+    version: "{{ version_spec.rollup_versions[0].ansible_commit }}"
     accept_hostkey: yes
     force: yes
 

--- a/vars/custom_overrides.yaml.example
+++ b/vars/custom_overrides.yaml.example
@@ -106,6 +106,11 @@
 # rollup_hyperlane_bridge_domain: 5555
 # rollup_deferred_slots_count: 100000
 # rollup_hyperlane_meter_delivery_counter_after_height: 0
+# rollup_chain_hash_overrides:
+#   - start_height: 0
+#     end_height: 1000
+#     chain_hash: "0xabc...32_bytes_hex"
+#     grace_period: 100
 
 # ============================================
 # zkVM - Risc0

--- a/vars/runtime_vars.yaml.template
+++ b/vars/runtime_vars.yaml.template
@@ -98,6 +98,13 @@ signer_private_key: ""
 # Hyperlane meter delivery counter after height (integer)
 # rollup_hyperlane_meter_delivery_counter_after_height: 0
 
+# Chain hash overrides (list of objects)
+# rollup_chain_hash_overrides:
+#   - start_height: 0
+#     end_height: 1000
+#     chain_hash: "0xabc...32_bytes_hex"
+#     grace_period: 100
+
 # ============================================================================
 # INFRASTRUCTURE CONFIGURATION (optional overrides)
 # ============================================================================


### PR DESCRIPTION
This PR adds support for chain hash overrides. It also fixes two minor bugs:
1. The ansible branch param passed from CDK was not passed through to recursive invocations. This made it roughly useless
2. The rollup genesis config doesn't set `admin_addresses` on the sequencer, which means that some valid callmessages from private keys we control are rejected by the sequencer as unauthorized. This PR fixes the issue.