### PR TITLE
Add support for secondary influxdb output

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,26 @@ signer_private_key: "YOUR_PRIVATE_KEY_HEX"
 #### Monitoring Secrets
 **File:** `vars/monitoring_secrets.yaml`
 
-Contains Grafana Loki and Tempo credentials.
+Contains InfluxDB, Grafana Loki, and Tempo credentials. Also supports optional secondary InfluxDB outputs for sending metrics to multiple destinations (e.g., internal InfluxDB + Grafana Cloud):
+
+```yaml
+influxdb_token: "YOUR_INFLUXDB_TOKEN"
+
+# Optional: tokens for secondary InfluxDB outputs (keyed by name)
+# Output configs are defined in custom_overrides.yaml
+influxdb_secondary_tokens:
+  grafana-cloud: "YOUR_SECONDARY_TOKEN"
+```
+
+Secondary output configs (non-secret) go in `vars/custom_overrides.yaml`:
+
+```yaml
+influxdb_secondary_outputs:
+  - name: "grafana-cloud"
+    url: "https://influx-prod.grafana.net"
+    org: "my-org"
+    bucket: "prod-metrics"
+```
 
 ### How to Override Variables
 

--- a/roles/common/defaults/main.yaml
+++ b/roles/common/defaults/main.yaml
@@ -139,6 +139,11 @@ telegraf_extra_tags: {}
 influxdb_org: "Sovereign Labs"
 influxdb_bucket: "sov-dev"
 
+# Secondary InfluxDB outputs (optional)
+# Define outputs in custom_overrides.yaml, tokens in monitoring_secrets.yaml
+influxdb_secondary_outputs: []
+influxdb_secondary_tokens: {}
+
 # Loki configuration
 grafana_loki_url: "https://loki.sov-obs.xyz/loki/api/v1/push"
 grafana_loki_username: "sov-logger"

--- a/roles/common/templates/telegraf.conf.j2
+++ b/roles/common/templates/telegraf.conf.j2
@@ -40,6 +40,18 @@
 #  organization = """
 #  bucket = ""
 {% endif %}
+{% for output in influxdb_secondary_outputs %}
+{% set token = influxdb_secondary_tokens[output.name] | default('') %}
+{% if token %}
+
+# Secondary output: {{ output.name }}
+[[outputs.influxdb_v2]]
+  urls = ["{{ output.url }}"]
+  organization = "{{ output.org }}"
+  bucket = "{{ output.bucket }}"
+  token = "{{ token }}"
+{% endif %}
+{% endfor %}
 
 # Collectors
 [[inputs.socket_listener]]

--- a/vars/custom_overrides.yaml.example
+++ b/vars/custom_overrides.yaml.example
@@ -22,6 +22,13 @@
 # loki_url: "https://logs-prod-017.grafana.net/loki/api/v1/push"
 # tempo_url: "https://tempo-prod-10-prod-us-central-0.grafana.net:443"
 
+# Secondary InfluxDB outputs (tokens go in monitoring_secrets.yaml)
+# influxdb_secondary_outputs:
+#   - name: "grafana-cloud"
+#     url: "https://influx-prod.grafana.net"
+#     org: "my-org"
+#     bucket: "prod-metrics"
+
 # ============================================
 # Rollup Configuration
 # ============================================

--- a/vars/monitoring_secrets.yaml.example
+++ b/vars/monitoring_secrets.yaml.example
@@ -11,6 +11,11 @@
 # Used by Telegraf to send metrics to Grafana Cloud InfluxDB
 influxdb_token: "YOUR_INFLUXDB_TOKEN_HERE"
 
+# Secondary InfluxDB output tokens (keyed by output name)
+# Output configs are defined in custom_overrides.yaml or role defaults
+# influxdb_secondary_tokens:
+#   grafana-cloud: "YOUR_SECONDARY_TOKEN"
+
 # Grafana Loki token for log aggregation
 # Used by Grafana Alloy to send logs to Grafana Cloud Loki
 grafana_loki_token: "YOUR_LOKI_TOKEN_HERE"

--- a/vars/runtime_vars.yaml.template
+++ b/vars/runtime_vars.yaml.template
@@ -121,6 +121,13 @@ signer_private_key: ""
 # influxdb_org: "Sovereign Labs"
 # influxdb_bucket: "sov-dev"
 
+# Secondary InfluxDB outputs (optional, send metrics to multiple destinations)
+# influxdb_secondary_outputs:
+#   - name: "grafana-cloud"
+#     url: "https://influx-prod.grafana.net"
+#     org: "my-org"
+#     bucket: "prod-metrics"
+
 # Loki configuration
 # grafana_loki_url: "https://loki.sov-obs.xyz/loki/api/v1/push"
 # grafana_loki_username: "sov-logger"
@@ -137,3 +144,7 @@ signer_private_key: ""
 # influxdb_token: ""
 # grafana_loki_token: ""
 # grafana_tempo_token: ""
+
+# Secondary InfluxDB output tokens (keyed by output name from influxdb_secondary_outputs)
+# influxdb_secondary_tokens:
+#   grafana-cloud: "YOUR_SECONDARY_TOKEN"


### PR DESCRIPTION
Adds support for multiple influxdb outputs


```yaml
influxdb_remote_url: "http://influxdb.sov-obs.xyz:8086"
influxdb_token: "MAIN_TOKEN"
influxdb_secondary_outputs:
  - name: "influxdb_2"
    url: "https://influxdb-2.sov-obs.xyz"
    org: "Sovereign Labs"
    bucket: "sov-dev"
influxdb_secondary_tokens:
  influxdb_2: "SECONDARY_TOKEN"
```

Tested manually on sov-hetzner-7.

Secrets are split from main declaration for security