### PR TITLE
Update recent changes in genesis and rollup config

### DIFF
--- a/roles/rollup-build/defaults/main.yaml
+++ b/roles/rollup-build/defaults/main.yaml
@@ -75,7 +75,8 @@ rollup_state_user_preallocate_ht: true
 rollup_sequencer_address: "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 # 7 MiB
 rollup_max_batch_size_bytes: 7340032
-rollup_max_concurrent_blobs: 128
+rollup_max_concurrent_batch_blobs: 128
+rollup_max_concurrent_proof_blobs: 128
 rollup_max_allowed_node_distance_behind: 10
 
 # Rate limiter - only applies to preferred sequencer

--- a/roles/rollup-build/templates/genesis.json.j2
+++ b/roles/rollup-build/templates/genesis.json.j2
@@ -112,10 +112,6 @@
       "limit_contract_code_size": 524288,
       "coinbase": "0x0000000000000000000000000000000000000000",
       "block_gas_limit": {{ rollup_genesis_evm_block_gas_limit }},
-      "base_fee_params": {
-        "max_change_denominator": 8,
-        "elasticity_multiplier": 2
-      },
       "hardforks": [[0, "CANCUN"]]
     },
     "admin": "{{ rollup_sequencer_address }}"

--- a/roles/rollup-build/templates/rollup_config.toml.j2
+++ b/roles/rollup-build/templates/rollup_config.toml.j2
@@ -28,10 +28,12 @@ aggregated_proof_block_jump = 1
 prover_address = "{{ rollup_sequencer_address }}"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 20
+max_number_of_aggregated_proofs_in_memory = 10
 
 [sequencer]
 max_batch_size_bytes = {{ rollup_max_batch_size_bytes }}
-max_concurrent_blobs = {{ rollup_max_concurrent_blobs }}
+max_concurrent_batch_blobs = {{ rollup_max_concurrent_batch_blobs }}
+max_concurrent_proof_blobs = {{ rollup_max_concurrent_proof_blobs }}
 max_allowed_node_distance_behind = {{ rollup_max_allowed_node_distance_behind }}
 rollup_address = "{{ rollup_sequencer_address }}"
 blob_processing_timeout_secs = 60

--- a/roles/rollup/tasks/rollup_manager.yaml
+++ b/roles/rollup/tasks/rollup_manager.yaml
@@ -38,19 +38,14 @@
 - name: copy rollup manager binary to sovereign's home directory
   vars:
     build_profile_path: "{{ 'release' if not debug else 'debug' }}"
-  ansible.builtin.shell:
-    cmd: cp /home/ubuntu/{{ rollup_manager_repo_dir }}/target/{{ build_profile_path }}/sov-rollup-manager /home/sovereign/{{ rollup_manager_bin }}
-  become: true
-  become_user: root
-
-- name: set owner, group, and permissions on the rollup manager binary
-  ansible.builtin.file:
-    path: /home/sovereign/{{ rollup_manager_bin }}
+  ansible.builtin.copy:
+    src: "/home/ubuntu/{{ rollup_manager_repo_dir }}/target/{{ build_profile_path }}/sov-rollup-manager"
+    dest: "/home/sovereign/{{ rollup_manager_bin }}"
+    remote_src: yes
     owner: sovereign
     group: sovereign
     mode: '0755'
   become: true
-  become_user: root
 
 - name: render rollup-manager-config.json
   become: true


### PR DESCRIPTION

## Params

`rollup_config.toml`:

```
rollup_max_concurrent_batch_blobs - exposed via default var
rollup_max_concurrent_proof_blobs - exposed via default var
max_number_of_aggregated_proofs_in_memory - hardcoded
```

`genesis.json`: remove `base_fee_params`

## Fixes

Fixes when doing ansible-pull on running machine:

```
  fatal: [localhost]: FAILED! => {"changed": true, "cmd": "cp /home/ubuntu/sov-rollup-manager/target/release/sov-rollup-manager /home/sovereign/rollup-manager", "delta": "0:00:00.003180", "end": "2026-05-15 09:49:41.789530", "msg":
  "non-zero return code", "rc": 1, "start": "2026-05-15 09:49:41.786350", "stderr": "cp: cannot create regular file '/home/sovereign/rollup-manager': Text file busy", "stderr_lines": ["cp: cannot create regular file
  '/home/sovereign/rollup-manager': Text file busy"], "stdout": "", "stdout_lines": []}
```

 The cleanest fix is to use Ansible's built-in copy module, which writes to a temp file and atomically renames it — rename() works even on running binaries because it just updates a directory entry without touching the busy inode.



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter-ansible/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->