### PR TITLE
Operating mode and fixes for recent updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ All configuration is organized in role-based defaults and secret files:
 - `rollup_repo` - Full git URL (default: "https://github.com/Sovereign-Labs/rollup-starter.git")
   - Use HTTPS for public repos, `git@github.com:org/repo.git` for private repos with SSH keys
 - `rollup_commit_hash` - ⚠️ **Git commit to deploy** (update this!)
-- `zkvm_role` - zkVM implementation (default: "mock_zkvm", option: "risc0")
+- `zkvm_role` - zkVM implementation (default: "mock_zkvm", options: "risc0", "sp1")
+- `rollup_genesis_operating_mode` - Genesis operating mode: "operator", "zk", or "optimistic"
+- `rollup_genesis_inner_code_commitment` / `rollup_genesis_outer_code_commitment` - Eight-integer code commitments; required to be non-zero for "zk"/"optimistic" with "risc0" or "sp1"
 - `debug` - Build in debug mode (default: false) for faster iteration
 - `rollup_http_port` - API port (default: 12346)
 - `wipe` - Wipe data on deployment (default: false)

--- a/roles/rollup-build/defaults/main.yaml
+++ b/roles/rollup-build/defaults/main.yaml
@@ -35,6 +35,10 @@ da_store: "/mnt/da"
 # Rollup operating mode. One of: "operator", "zk", "optimistic".
 # "operator" omits the [proof_manager] section; "zk"/"optimistic" require it.
 rollup_genesis_operating_mode: "operator"
+# Genesis code commitments for the rollup guest programs.
+# Real risc0/sp1 deployments in "zk" or "optimistic" mode must override these.
+rollup_genesis_inner_code_commitment: [0, 0, 0, 0, 0, 0, 0, 0]
+rollup_genesis_outer_code_commitment: [0, 0, 0, 0, 0, 0, 0, 0]
 rollup_genesis_bank_disable_admin: false
 rollup_genesis_seq_min_bond: 5000
 rollup_genesis_seq_init_bond: 100000000000000000000000000000000

--- a/roles/rollup-build/defaults/main.yaml
+++ b/roles/rollup-build/defaults/main.yaml
@@ -32,6 +32,9 @@ da_store: "/mnt/da"
 #    -a "src=roles/rollup-build/templates/genesis.json.j2 dest=/tmp/genesis.json" \
 #     -e "@roles/rollup-build/defaults/main.yaml" \
 #    -e "@path/to/your/vars.yaml"
+# Rollup operating mode. One of: "operator", "zk", "optimistic".
+# "operator" omits the [proof_manager] section; "zk"/"optimistic" require it.
+rollup_genesis_operating_mode: "operator"
 rollup_genesis_bank_disable_admin: false
 rollup_genesis_seq_min_bond: 5000
 rollup_genesis_seq_init_bond: 100000000000000000000000000000000

--- a/roles/rollup-build/tasks/main.yaml
+++ b/roles/rollup-build/tasks/main.yaml
@@ -2,6 +2,12 @@
 # Rollup build role - builds a single version of the rollup binary
 # This role can be invoked standalone or called by the rollup role
 
+- name: Validate operating mode is supported
+  assert:
+    that: "rollup_genesis_operating_mode | default('') in ['operator', 'zk', 'optimistic']"
+    fail_msg: "rollup_genesis_operating_mode must be one of: operator, zk, optimistic (got '{{ rollup_genesis_operating_mode | default('') }}')."
+    quiet: true
+
 - name: Load DA-specific variables
   include_vars: "{{ role_path }}/vars/{{ data_availability_role }}.yaml"
 

--- a/roles/rollup-build/tasks/main.yaml
+++ b/roles/rollup-build/tasks/main.yaml
@@ -8,6 +8,33 @@
     fail_msg: "rollup_genesis_operating_mode must be one of: operator, zk, optimistic (got '{{ rollup_genesis_operating_mode | default('') }}')."
     quiet: true
 
+- name: Validate genesis code commitments
+  assert:
+    that:
+      - rollup_genesis_inner_code_commitment is defined
+      - rollup_genesis_outer_code_commitment is defined
+      - rollup_genesis_inner_code_commitment is sequence
+      - rollup_genesis_inner_code_commitment is not string
+      - rollup_genesis_outer_code_commitment is sequence
+      - rollup_genesis_outer_code_commitment is not string
+      - rollup_genesis_inner_code_commitment | length == 8
+      - rollup_genesis_outer_code_commitment | length == 8
+      - rollup_genesis_inner_code_commitment | select('integer') | list | length == 8
+      - rollup_genesis_outer_code_commitment | select('integer') | list | length == 8
+    fail_msg: "rollup_genesis_inner_code_commitment and rollup_genesis_outer_code_commitment must each be a list of exactly 8 integers."
+    quiet: true
+
+- name: Validate real zkVM genesis code commitments are supplied
+  assert:
+    that:
+      - rollup_genesis_inner_code_commitment | reject('equalto', 0) | list | length > 0
+      - rollup_genesis_outer_code_commitment | reject('equalto', 0) | list | length > 0
+    fail_msg: "rollup_genesis_inner_code_commitment and rollup_genesis_outer_code_commitment must be non-zero for zk/optimistic genesis with zkvm_role={{ zkvm_role }}."
+    quiet: true
+  when:
+    - rollup_genesis_operating_mode in ['zk', 'optimistic']
+    - zkvm_role in ['risc0', 'sp1']
+
 - name: Load DA-specific variables
   include_vars: "{{ role_path }}/vars/{{ data_availability_role }}.yaml"
 

--- a/roles/rollup-build/tasks/main.yaml
+++ b/roles/rollup-build/tasks/main.yaml
@@ -17,11 +17,11 @@
       - rollup_genesis_inner_code_commitment is not string
       - rollup_genesis_outer_code_commitment is sequence
       - rollup_genesis_outer_code_commitment is not string
-      - rollup_genesis_inner_code_commitment | length == 8
-      - rollup_genesis_outer_code_commitment | length == 8
-      - rollup_genesis_inner_code_commitment | select('integer') | list | length == 8
-      - rollup_genesis_outer_code_commitment | select('integer') | list | length == 8
-    fail_msg: "rollup_genesis_inner_code_commitment and rollup_genesis_outer_code_commitment must each be a list of exactly 8 integers."
+      - rollup_genesis_inner_code_commitment | length >= 8
+      - rollup_genesis_outer_code_commitment | length >= 8
+      - (rollup_genesis_inner_code_commitment | select('integer') | list | length) == (rollup_genesis_inner_code_commitment | length)
+      - (rollup_genesis_outer_code_commitment | select('integer') | list | length) == (rollup_genesis_outer_code_commitment | length)
+    fail_msg: "rollup_genesis_inner_code_commitment and rollup_genesis_outer_code_commitment must each be a list of at least 8 integers."
     quiet: true
 
 - name: Validate real zkVM genesis code commitments are supplied

--- a/roles/rollup-build/templates/genesis.json.j2
+++ b/roles/rollup-build/templates/genesis.json.j2
@@ -45,8 +45,8 @@
     "current_time": 0,
     "operating_mode": "{{ rollup_genesis_operating_mode }}",
     {% if rollup_genesis_bank_disable_gas_token %}"admin": "{{ rollup_sequencer_address }}",{% endif %}
-    "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-    "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
+    "inner_code_commitment": {{ rollup_genesis_inner_code_commitment | to_json }},
+    "outer_code_commitment": {{ rollup_genesis_outer_code_commitment | to_json }},
     "genesis_da_height": {{ genesis_da_height }}
   },
   "paymaster": {

--- a/roles/rollup-build/templates/genesis.json.j2
+++ b/roles/rollup-build/templates/genesis.json.j2
@@ -43,7 +43,7 @@
   },
   "chain_state": {
     "current_time": 0,
-    "operating_mode": "operator",
+    "operating_mode": "{{ rollup_genesis_operating_mode }}",
     {% if rollup_genesis_bank_disable_gas_token %}"admin": "{{ rollup_sequencer_address }}",{% endif %}
     "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
     "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],

--- a/roles/rollup-build/templates/rollup_config.toml.j2
+++ b/roles/rollup-build/templates/rollup_config.toml.j2
@@ -22,6 +22,7 @@ bind_port = {{ rollup_http_port }}
 [monitoring]
 telegraf_address = "127.0.0.1:8094"
 
+{% if rollup_genesis_operating_mode != "operator" %}
 [proof_manager]
 aggregated_proof_block_jump = 1
 # For now sequencer and prover same thing
@@ -29,11 +30,12 @@ prover_address = "{{ rollup_sequencer_address }}"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 20
 max_number_of_aggregated_proofs_in_memory = 10
+max_concurrent_proof_blobs = {{ rollup_max_concurrent_proof_blobs }}
+{% endif %}
 
 [sequencer]
 max_batch_size_bytes = {{ rollup_max_batch_size_bytes }}
 max_concurrent_batch_blobs = {{ rollup_max_concurrent_batch_blobs }}
-max_concurrent_proof_blobs = {{ rollup_max_concurrent_proof_blobs }}
 max_allowed_node_distance_behind = {{ rollup_max_allowed_node_distance_behind }}
 rollup_address = "{{ rollup_sequencer_address }}"
 blob_processing_timeout_secs = 60

--- a/vars/custom_overrides.yaml.example
+++ b/vars/custom_overrides.yaml.example
@@ -47,6 +47,14 @@
 # zkVM implementation: "mock_zkvm", "risc0", or "sp1"
 # zkvm_role: "mock_zkvm"
 
+# Genesis operating mode: "operator", "zk", or "optimistic"
+# rollup_genesis_operating_mode: "operator"
+
+# Genesis code commitments. Required to be non-zero when using zk/optimistic
+# mode with a real zkVM ("risc0" or "sp1").
+# rollup_genesis_inner_code_commitment: [0, 0, 0, 0, 0, 0, 0, 0]
+# rollup_genesis_outer_code_commitment: [0, 0, 0, 0, 0, 0, 0, 0]
+
 # Build mode: true for debug, false for release
 # debug: true
 

--- a/vars/runtime_vars.yaml.template
+++ b/vars/runtime_vars.yaml.template
@@ -34,6 +34,15 @@ rollup_commit_hash: "770a88a25576640b1e76b9385bf61b05452d60dd"
 # Options: "mock_zkvm" (fast, for development), "risc0", or "sp1" (full proving)
 zkvm_role: "mock_zkvm"
 
+# Genesis operating mode
+# Options: "operator", "zk", or "optimistic"
+rollup_genesis_operating_mode: "operator"
+
+# Genesis code commitments. Required to be non-zero when using zk/optimistic
+# mode with a real zkVM ("risc0" or "sp1").
+# rollup_genesis_inner_code_commitment: [0, 0, 0, 0, 0, 0, 0, 0]
+# rollup_genesis_outer_code_commitment: [0, 0, 0, 0, 0, 0, 0, 0]
+
 # Sequencer type
 # "Preferred": will run the preferred sequencer that provides soft confirmations.
 # "Standard": will run a basic near-stateless sequencer.


### PR DESCRIPTION
Makes `operating_mode` a variable, keeping default value to `operator`

Adds logic for skip `proof_manager` and other updates from https://github.com/Sovereign-Labs/sovereign-sdk/pull/2881
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter-ansible/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->