### PR TITLE
Use same tags in alloy and telegraf

### DIFF
--- a/roles/common/tasks/custom_vars.yaml
+++ b/roles/common/tasks/custom_vars.yaml
@@ -2,6 +2,10 @@
   set_fact:
     effective_hostname: "{{ custom_host_label | default(inventory_hostname) }}"
 
+- name: set effective environment
+  set_fact:
+    effective_environment: "{{ custom_environment | default('sov-aws-dev', true) }}"
+
 - name: load disk profile
   set_fact:
     disk_profile_raw: "{{ disk_custom if disk_profile == 'custom' else disk_profiles[disk_profile] }}"

--- a/roles/common/templates/alloy.conf.j2
+++ b/roles/common/templates/alloy.conf.j2
@@ -31,6 +31,18 @@ otelcol.processor.attributes "custom_labels" {
     action = "insert"
     value = "{{ effective_hostname }}"
   }
+  action {
+    key = "environment"
+    action = "insert"
+    value = "{{ effective_environment }}"
+  }
+{% if deployment_name is defined and deployment_name %}
+  action {
+    key = "deployment_name"
+    action = "insert"
+    value = "{{ deployment_name }}"
+  }
+{% endif %}
   output {
     traces = [otelcol.exporter.otlp.grafanacloud.input]
   }
@@ -67,6 +79,10 @@ loki.process "add_hostname" {
   stage.static_labels {
     values = {
       host = "{{ effective_hostname }}",
+      environment = "{{ effective_environment }}",
+{% if deployment_name is defined and deployment_name %}
+      deployment_name = "{{ deployment_name }}",
+{% endif %}
     }
   }
 }

--- a/roles/common/templates/telegraf.conf.j2
+++ b/roles/common/templates/telegraf.conf.j2
@@ -1,11 +1,7 @@
 # Based on https://github.com/Sovereign-Labs/sov-observability/blob/main/telegraf/telegraf.conf
 # All updates must be ported
 [global_tags]
-{% if custom_environment is defined and custom_environment %}
-  environment = "{{ custom_environment }}"
-{% else %}
-  environment = "sov-aws-dev"
-{% endif %}
+  environment = "{{ effective_environment }}"
 {% if deployment_name is defined and deployment_name %}
   deployment_name = "{{ deployment_name }}"
 {% endif %}

--- a/roles/common/templates/telegraf.conf.j2
+++ b/roles/common/templates/telegraf.conf.j2
@@ -63,7 +63,8 @@
   percpu = true
   totalcpu = true
   collect_cpu_time = false
-  report_active = falsecore_tags = false
+  report_active = false
+  core_tags = false
 [[inputs.mem]]
 
 # Storage


### PR DESCRIPTION
Configure alloy to support `enivronment` and `deployment_name` so we have have auto-assigned alerts in grafana
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter-ansible/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->