### PR TITLE
Add leader election config support to rollup-build

### DIFF
--- a/roles/rollup-build/defaults/main.yaml
+++ b/roles/rollup-build/defaults/main.yaml
@@ -124,6 +124,18 @@ rollup_node_id: "node1"
 # Optional PostgreSQL connection string for sequencer
 # rollup_sequencer_postgres_connection_string: "postgresql://user:pass@host/db"
 
+# Leader election timing (preferred sequencer with Postgres only).
+# These map to [sequencer.preferred.postgres_config.leader_election] in
+# rollup_config.toml and are only relevant when a Postgres connection string
+# is configured.
+# Max time (ms) without a heartbeat before a leader is considered inactive.
+rollup_leader_election_leader_timeout_millis: 1000
+# Min time (ms) after leader acquisition before another node can take over.
+# Prevents rapid leader flapping.
+rollup_leader_election_grace_period_millis: 10000
+# Interval (ms) between heartbeat updates.
+rollup_leader_election_heartbeat_interval_millis: 100
+
 # Optional comma separated string of EVM addresses for RAM pinning (privileged deployers)
 evm_pinned_addresses: ""
 # Whether reverted EVM txs should be published to DA

--- a/roles/rollup-build/templates/rollup_config.toml.j2
+++ b/roles/rollup-build/templates/rollup_config.toml.j2
@@ -58,6 +58,11 @@ num_cache_warmup_workers = 0
 postgres_connection_string = "{{ rollup_sequencer_postgres_connection_string }}"
 node_role = "{{ rollup_node_role }}"
 node_id = "{{ rollup_node_id }}"
+
+[sequencer.preferred.postgres_config.leader_election]
+leader_timeout_millis = {{ rollup_leader_election_leader_timeout_millis }}
+grace_period_millis = {{ rollup_leader_election_grace_period_millis }}
+heartbeat_interval_millis = {{ rollup_leader_election_heartbeat_interval_millis }}
 {% endif %}
 {% else %}
 [sequencer.standard]

--- a/vars/custom_overrides.yaml.example
+++ b/vars/custom_overrides.yaml.example
@@ -87,6 +87,20 @@
 #     refill_rate: 1
 
 # ============================================
+# Leader Election (Preferred Sequencer + Postgres Only)
+# ============================================
+# Maps to [sequencer.preferred.postgres_config.leader_election]. Only applies
+# when rollup_sequencer_postgres_connection_string is set. Values shown are the
+# role defaults.
+
+# Max time (ms) without a heartbeat before a leader is considered inactive
+# rollup_leader_election_leader_timeout_millis: 1000
+# Min time (ms) after leader acquisition before another node can take over
+# rollup_leader_election_grace_period_millis: 10000
+# Interval (ms) between heartbeat updates
+# rollup_leader_election_heartbeat_interval_millis: 100
+
+# ============================================
 # Data Availability - Mock DA
 # ============================================
 

--- a/vars/runtime_vars.yaml.template
+++ b/vars/runtime_vars.yaml.template
@@ -48,6 +48,14 @@ rollup_genesis_operating_mode: "operator"
 # "Standard": will run a basic near-stateless sequencer.
 rollup_sequencer_kind: "preferred"
 
+# Leader election timing (preferred sequencer with Postgres only).
+# Maps to [sequencer.preferred.postgres_config.leader_election]. Only applied
+# when rollup_sequencer_postgres_connection_string is set. Values below are the
+# role defaults — uncomment to override.
+# rollup_leader_election_leader_timeout_millis: 1000
+# rollup_leader_election_grace_period_millis: 10000
+# rollup_leader_election_heartbeat_interval_millis: 100
+
 # Build mode
 # true = debug build (faster compile, larger binary, more logging)
 # false = release build (slower compile, optimized binary)


### PR DESCRIPTION
Wire the [sequencer.preferred.postgres_config.leader_election] parameters (leader_timeout_millis, grace_period_millis, heartbeat_interval_millis) through the rollup-build role so they can be tuned like other config values.

These only apply when a Postgres connection string is configured. Defaults match the rollup's built-in LeaderElectionConfig defaults (1000/10000/100), so existing deployments are unaffected.

The cdk will be updated once this branch is merged.