### PR TITLE
Allow lenient expiry time when restoring certificates from tarball on new proxy

### DIFF
--- a/roles/proxy/README.md
+++ b/roles/proxy/README.md
@@ -52,6 +52,11 @@ A **single** multi-SAN Let's Encrypt cert covers
   certbot run, so the next replacement re-issues via certbot once. The S3 backup
   is a single fixed-key tarball, so nothing is orphaned — the restored bundle's
   directory name just no longer matches and is rebuilt.
+- **Restored certs use a small boot margin.** A replacement may not be able to
+  complete HTTP-01 until after traffic shifts, so restored backups are accepted
+  when they are valid for `proxy_cert_restore_min_valid_days` (default: 1), while
+  newly issued or locally renewable certs still use the normal
+  `proxy_cert_expiry_threshold_days` freshness gate (default: 30).
 - **`proxy_unlimited_domains` is rate-exempt by `Host`** — valid API-key
   traffic is unmetered; failed-auth attempts remain per-IP throttled.
 - **Only-unlimited deployments expose no anonymous endpoint.** With

--- a/roles/proxy/defaults/main.yaml
+++ b/roles/proxy/defaults/main.yaml
@@ -77,6 +77,11 @@ proxy_aws_cli_bin: "/snap/bin/aws"
 proxy_cert_s3_bucket: ""
 proxy_cert_s3_region: ""
 proxy_cert_s3_key: "letsencrypt.tar.gz"
+# Minimum validity required for a restored backup during replacement boot.
+# Renewal is a daily cron on the traffic-owning proxy; a replacement may not be
+# able to complete HTTP-01 until after the EIP shifts, so this is intentionally
+# lower than the normal renewal freshness threshold.
+proxy_cert_restore_min_valid_days: 1
 proxy_cert_expiry_threshold_days: 30
 
 # GeoIP2 country blocking (opt-in). When enabled, the role builds

--- a/roles/proxy/tasks/_assess_cert.yaml
+++ b/roles/proxy/tasks/_assess_cert.yaml
@@ -1,9 +1,13 @@
 ---
-# Sets `_check_cert_ok` based on the cert at `_check_path`.
-# True when cert.pem, fullchain.pem, privkey.pem all exist, the cert is valid
-# for at least `_check_threshold_days` more days (defaults to
-# `proxy_cert_expiry_threshold_days`; HTTPS-readiness callers pass 0 = "valid
-# right now"), and its SANs cover every domain in `_proxy_all_cert_domains`.
+# Sets `_check_cert_ok` based on the cert at `_check_path` and records failure
+# details in `_check_cert_status` for debug output. True when cert.pem,
+# fullchain.pem, privkey.pem all exist, the cert is valid for at least
+# `_check_threshold_days` more days (defaults to `proxy_cert_expiry_threshold_days`),
+# and its SANs cover every domain in `_proxy_all_cert_domains`.
+
+- name: Set cert assessment threshold
+  set_fact:
+    _check_effective_threshold_days: "{{ _check_threshold_days | default(proxy_cert_expiry_threshold_days) | int }}"
 
 - name: Stat cert bundle at {{ _check_path }}
   become: true
@@ -20,12 +24,26 @@
   community.crypto.x509_certificate_info:
     path: "{{ _check_path }}/cert.pem"
     valid_at:
-      threshold: "+{{ _check_threshold_days | default(proxy_cert_expiry_threshold_days) }}d"
+      threshold: "+{{ _check_effective_threshold_days }}d"
   register: _check_cert_info
   when: _check_files.results[0].stat.exists
 
 - name: Decide cert ok
   set_fact:
+    _check_file_status: "{{ dict(_check_files.results | map(attribute='item') | zip(_check_files.results | map(attribute='stat.exists'))) }}"
+    _check_cert_sans: >-
+      {{
+        _check_cert_info.subject_alt_name | default([])
+        | select('match', '^DNS:') | map('regex_replace', '^DNS:', '') | list
+      }}
+    _check_missing_domains: >-
+      {{
+        _proxy_all_cert_domains
+        | difference(
+            _check_cert_info.subject_alt_name | default([])
+            | select('match', '^DNS:') | map('regex_replace', '^DNS:', '') | list
+          )
+      }}
     _check_cert_ok: >-
       {{
         (_check_files.results | map(attribute='stat.exists') | select | list | length == 3)
@@ -39,3 +57,24 @@
           | length == 0
         )
       }}
+
+- name: Record cert assessment details
+  set_fact:
+    _check_cert_status:
+      path: "{{ _check_path }}"
+      ok: "{{ _check_cert_ok }}"
+      threshold_days: "{{ _check_effective_threshold_days }}"
+      files: "{{ _check_file_status }}"
+      valid_at_threshold: "{{ _check_cert_info.valid_at.threshold | default(false) }}"
+      not_before: "{{ _check_cert_info.not_before | default('n/a') }}"
+      not_after: "{{ _check_cert_info.not_after | default('n/a') }}"
+      expected_domains: "{{ _proxy_all_cert_domains }}"
+      cert_dns_sans: "{{ _check_cert_sans }}"
+      missing_domains: "{{ _check_missing_domains }}"
+
+- name: Show rejected cert details
+  ansible.builtin.debug:
+    var: _check_cert_status
+  when:
+    - _check_debug_rejections | default(false) | bool
+    - not (_check_cert_ok | default(false))

--- a/roles/proxy/tasks/main.yaml
+++ b/roles/proxy/tasks/main.yaml
@@ -42,7 +42,7 @@
   include_tasks: _assess_cert.yaml
   vars:
     _check_path: "{{ proxy_letsencrypt_live_dir }}"
-    _check_threshold_days: 0          # servable now (not expired); 30d freshness is for renew/restore
+    _check_threshold_days: 0          # servable now; restore and renewal paths use stricter thresholds
   when: proxy_ssl_enabled | bool
 
 - name: Set HTTPS readiness flag (pre-render)
@@ -329,13 +329,27 @@
   include_tasks: _assess_cert.yaml
   vars:
     _check_path: "{{ proxy_letsencrypt_live_dir }}"
-    _check_threshold_days: 0          # servable now; this gate only activates HTTPS, never downgrades
+    _check_threshold_days: "{{ (proxy_cert_restored | default(false)) | ternary(proxy_cert_restore_min_valid_days, proxy_cert_expiry_threshold_days) }}"
+    _check_debug_rejections: true
   when: proxy_ssl_enabled | bool
 
 - name: Set HTTPS readiness flag (post-certbot)
   set_fact:
     proxy_https_ready: "{{ _check_cert_ok | default(false) }}"
   when: proxy_ssl_enabled | bool
+
+- name: Show certbot output when HTTPS is still not ready
+  ansible.builtin.debug:
+    msg: |
+      certbot rc={{ certbot_result.rc | default('n/a') }}
+      stdout:
+      {{ certbot_result.stdout | default('') | indent(2) }}
+      stderr:
+      {{ certbot_result.stderr | default('') | indent(2) }}
+  when:
+    - proxy_ssl_enabled | bool
+    - certbot_result is defined
+    - not (proxy_https_ready | default(false))
 
 - name: Fail when HTTPS is required but no valid certificate is available
   assert:

--- a/roles/proxy/tasks/s3_certs.yaml
+++ b/roles/proxy/tasks/s3_certs.yaml
@@ -20,6 +20,8 @@
   include_tasks: _assess_cert.yaml
   vars:
     _check_path: "{{ proxy_letsencrypt_live_dir }}"
+    _check_threshold_days: "{{ proxy_cert_expiry_threshold_days }}"
+    _check_debug_rejections: true
 
 - name: Capture local cert status
   set_fact:
@@ -69,6 +71,8 @@
   include_tasks: _assess_cert.yaml
   vars:
     _check_path: "{{ proxy_letsencrypt_live_dir }}"
+    _check_threshold_days: "{{ proxy_cert_restore_min_valid_days }}"
+    _check_debug_rejections: true
   when: not _local_cert_ok
 
 - name: Capture restored cert status

--- a/vars/runtime_vars.yaml.template
+++ b/vars/runtime_vars.yaml.template
@@ -101,6 +101,9 @@ rollup_http_port: 12346
 # s3:PutObject, s3:DeleteObject on the bucket.
 # proxy_cert_s3_bucket: "my-rollup-proxy-certs"
 # proxy_cert_s3_region: "us-east-1"
+# Restored backups need enough validity to survive the replacement boot and the
+# next renewal cron. Fresh local/renewed certs still use the 30-day default.
+# proxy_cert_restore_min_valid_days: 1
 
 # Dynamic backend discovery (node-discovery Rust service)
 # When enabled, the proxy builds the node-discovery binary from rollup-starter


### PR DESCRIPTION
Also improves error messages to give a clear reason why SSL setup failed, both when rejecting a tarball from S3 and when certbot fails.